### PR TITLE
[WFTC-13] LocalUserTransaction provide methods to set it's availability

### DIFF
--- a/src/main/java/org/wildfly/transaction/TransactionPermission.java
+++ b/src/main/java/org/wildfly/transaction/TransactionPermission.java
@@ -36,7 +36,8 @@ public final class TransactionPermission extends AbstractNameSetOnlyPermission<T
         "registerAssociationListener",
         "registerCreationListener",
         "suspendRequests",
-        "resumeRequests"
+        "resumeRequests",
+        "modifyUserTransactionAvailability"
     );
 
     static final StringMapping<TransactionPermission> mapping = new StringMapping<>(NAMES, TransactionPermission::new);

--- a/src/main/java/org/wildfly/transaction/client/ContextTransactionManager.java
+++ b/src/main/java/org/wildfly/transaction/client/ContextTransactionManager.java
@@ -133,6 +133,14 @@ public final class ContextTransactionManager implements TransactionManager {
         }
     }
 
+    boolean isAvailable() {
+        return stateRef.get().available;
+    }
+
+    boolean setAvailable(boolean available) {
+        return stateRef.get().available = available;
+    }
+
     /**
      * Get the transaction manager instance.
      *
@@ -149,5 +157,6 @@ public final class ContextTransactionManager implements TransactionManager {
     static final class State {
         AbstractTransaction transaction;
         int timeout = 43200;
+        boolean available = true;
     }
 }

--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -331,4 +331,7 @@ public interface Log extends BasicLogger {
 
     @Message(id = 83, value = "Cannot import a new transaction on a suspended server")
     XAException suspendedCannotImportXa(@Field int errorCode);
+
+    @Message(id = 84, value = "UserTransaction access is forbidden in the current context")
+    IllegalStateException forbiddenContextForUserTransaction();
 }


### PR DESCRIPTION
This is done because of local transaction invoked in scope of
@Transactional interceptor
(e.g. from Narayana cdi implementation) needs to know if it's fine to
being invoked that context if not exception is thrown.

3.7 Transactional Annotation:
If an attempt is made to call any method of the UserTransaction
interface from within the scope of a bean or method annotated with
@Transactional and a Transactional.TxType other than NOT_SUPPORTED or
NEVER, an IllegalStateException must be thrown.

LocalUserTransaction `setAvailability`/`isAvailable` methods will be called through transactions spi from transaction Narayana cdi interceptor. 