### PR TITLE
[WFTC-9] adding suppressed part of exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,11 @@
     <description>Client library for applications using transactions with Wildfly</description>
 
     <properties>
-        <version.org.jboss.jboss-transaction-spi>7.5.0.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-processor>2.0.1.Final</version.org.jboss.logging.jboss-logging-processor>
         <version.org.jboss.logmanager>1.5.2.Final</version.org.jboss.logmanager>
-        <version.org.jboss.narayana>5.5.1.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>5.5.24.Final</version.org.jboss.narayana>
         <version.org.jboss.remoting>5.0.0.Beta16</version.org.jboss.remoting>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
         <version.org.jboss.xnio>3.5.0.Beta2</version.org.jboss.xnio>

--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
@@ -483,7 +483,11 @@ public abstract class JBossLocalTransactionProvider implements LocalTransactionP
         }
 
         private XAException initializeSuppressed(final XAException ex, final ImportedTransaction transaction) {
-            // TODO API does not yet exist for this
+            if(ex != null && transaction.supportsDeferredThrowables()) {
+                for(Throwable suppressedThrowable: transaction.getDeferredThrowables()) {
+                    ex.addSuppressed(suppressedThrowable);
+                }
+            }
             return ex;
         }
     }


### PR DESCRIPTION
...to exception thrown/serialized to client when transaction fails.

Moving to Narayana spi 7.6.0.Final where ImportedTransaction adds api
method call where suppressed exception could be taken from.
And using Narayana 5.5.24.Final where the api is implemented.