### PR TITLE
[WFTC-28] rethrowing XAException with XA_RETRY error code

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
@@ -467,6 +467,8 @@ public abstract class JBossLocalTransactionProvider implements LocalTransactionP
                         throw new XAException(XAException.XA_RETRY);
                     }
                 }
+            } catch (XAException e) {
+                throw initializeSuppressed(e, importedTransaction);
             } catch (HeuristicMixedException e) {
                 throw initializeSuppressed(Log.log.heuristicMixedXa(XAException.XA_HEURMIX, e), importedTransaction);
             } catch (RollbackException e) {


### PR DESCRIPTION
when transient error happens during commiting of imported transaction

https://issues.jboss.org/browse/WFTC-28