### PR TITLE
[WFTC-25] update with one recovery call after WFTC is started

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -78,6 +78,10 @@ public interface Log extends BasicLogger {
     @Message(value = "Got exception on outbound message")
     void outboundException(@Cause Throwable e);
 
+    @LogMessage(level = Logger.Level.TRACE)
+    @Message(value = "Failure on running doRecover during initialization")
+    void doRecoverFailureOnIntialization(@Cause Throwable e);
+
     // Regular messages
 
     @Message(id = 0, value = "No transaction associated with the current thread")

--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
@@ -80,6 +80,14 @@ public abstract class JBossLocalTransactionProvider implements LocalTransactionP
         this.staleTransactionTime = staleTransactionTime;
         this.ext = Assert.checkNotNullParam("ext", ext);
         this.tm = Assert.checkNotNullParam("tm", tm);
+
+        try {
+            ext.doRecover(null, null);
+        } catch (Exception e) {
+            // the recover method is called to load transactions from Narayana object store at startup
+            // if it fails we ignore, troubles will be adjusted during runtime
+            Log.log.doRecoverFailureOnIntialization(e);
+        }
     }
 
     /**
@@ -510,11 +518,6 @@ public abstract class JBossLocalTransactionProvider implements LocalTransactionP
                 if (doNotImport) {
                     imported = false;
                     transaction = ext.getTransaction(xid);
-
-                    if(transaction == null) {
-                        ext.doRecover(null, null);
-                        transaction = ext.getTransaction(xid);
-                    }
 
                     if (transaction == null) {
                         return null;


### PR DESCRIPTION
This is an adjustment of the patch provided for WFTC-25. I think it's not necessary to force running `doRecover` for each transaction which is not found amongst active ones. It should be enough to load transaction from the object store (by running `recover`) once at the start of the container. 

From my testing this change should fix the WFTC-25 in the same manner (at least from the  https://issues.jboss.org/browse/JBEAP-8635 integration point of view).

https://issues.jboss.org/browse/JBEAP-8635
https://issues.jboss.org/browse/WFTC-25