### PR TITLE
[WFLY-8951] Fix transaction comparision in LocalTransaction#unimportB…

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
+++ b/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
@@ -129,7 +129,7 @@ public final class LocalTransaction extends AbstractTransaction {
 
     void unimportBacking() {
         final ContextTransactionManager.State state = ContextTransactionManager.INSTANCE.getStateRef().get();
-        if (state.transaction == this) {
+        if (state.transaction.equals(this)) {
             state.transaction = null;
         }
     }


### PR DESCRIPTION
...acking

If the same transaction is represented by two different objects LocalTransaction#unimportBacking will fail to unimport it leading to errors as transaction stays associated with the thread.