### PR TITLE
[JBEAP-6156] throwing XAER_NOTA for unknown Xid for XA prepare/commit/rollback

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/provider/remoting/TransactionServerChannel.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/remoting/TransactionServerChannel.java
@@ -339,7 +339,11 @@ final class TransactionServerChannel {
         }
         securityIdentity.runAsObjIntConsumer((x, i) -> {
             try {
-                final ImportResult<LocalTransaction> importResult = localTransactionContext.findOrImportTransaction(x, 0);
+                final ImportResult<LocalTransaction> importResult = localTransactionContext.findOrImportTransaction(x, 0, true);
+                if (importResult == null) {
+                    writeExceptionResponse(M_RESP_XA_ROLLBACK, i, new XAException(XAException.XAER_NOTA));
+                    return;
+                }
                 // run operation while associated
                 importResult.getTransaction().performConsumer(SubordinateTransactionControl::rollback, importResult.getControl());
                 writeSimpleResponse(M_RESP_XA_ROLLBACK, i);
@@ -389,7 +393,11 @@ final class TransactionServerChannel {
         }
         securityIdentity.runAsObjIntConsumer((x, i) -> {
             try {
-                final ImportResult<LocalTransaction> importResult = localTransactionContext.findOrImportTransaction(x, 0);
+                final ImportResult<LocalTransaction> importResult = localTransactionContext.findOrImportTransaction(x, 0, true);
+                if (importResult == null) {
+                    writeExceptionResponse(M_RESP_XA_RB_ONLY, i, new XAException(XAException.XAER_NOTA));
+                    return;
+                }
                 importResult.getControl().end(XAResource.TMFAIL);
                 writeSimpleResponse(M_RESP_XA_RB_ONLY, i);
             } catch (XAException e) {
@@ -434,9 +442,8 @@ final class TransactionServerChannel {
         securityIdentity.runAsObjIntConsumer((x, i) -> {
             try {
                 final ImportResult<LocalTransaction> importResult = localTransactionContext.findOrImportTransaction(x, 0, true);
-                if(importResult == null) {
-                    final XAException xae = new XAException(XAException.XAER_NOTA);
-                    writeExceptionResponse(M_RESP_XA_BEFORE, i, xae);
+                if (importResult == null) {
+                    writeExceptionResponse(M_RESP_XA_BEFORE, i, new XAException(XAException.XAER_NOTA));
                     return;
                 }
                 // run operation while associated
@@ -488,7 +495,11 @@ final class TransactionServerChannel {
         }
         securityIdentity.runAsObjIntConsumer((x, i) -> {
             try {
-                final ImportResult<LocalTransaction> importResult = localTransactionContext.findOrImportTransaction(x, 0);
+                final ImportResult<LocalTransaction> importResult = localTransactionContext.findOrImportTransaction(x, 0, true);
+                if (importResult == null) {
+                    writeExceptionResponse(M_RESP_XA_PREPARE, invId, new XAException(XAException.XAER_NOTA));
+                    return;
+                }
                 // run operation while associated
                 int result = importResult.getControl().prepare();
                 if (result == XAResource.XA_RDONLY) {


### PR DESCRIPTION
This is a assumption of fixing the https://issues.jboss.org/browse/JBEAP-6156 where `XAER_NOTA` is expected to be thrown in case that remote client tries to commit/prepare/rollback non-existing transaction.

In general here we say that we want to import new transaction, we just tries to find it, if not found we throw the exception.