### PR TITLE
[WFTC-38] At JBossLocalTransctionProvider$Builder, validate in the co…

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
@@ -778,6 +778,7 @@ public abstract class JBossLocalTransactionProvider implements LocalTransactionP
             Assert.checkNotNullParam("extendedJBossXATerminator", extendedJBossXATerminator);
             Assert.checkNotNullParam("transactionManager", transactionManager);
             Assert.checkMinimumParameter("staleTransactionTime", 0, staleTransactionTime);
+            Assert.checkNotNullParam("xaResourceREcoveryRegistry", xaResourceRecoveryRegistry);
             if (transactionManager instanceof com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple
              || transactionManager instanceof com.arjuna.ats.jbossatx.jta.TransactionManagerDelegate) {
                 return new JBossJTALocalTransactionProvider(staleTransactionTime, extendedJBossXATerminator,


### PR DESCRIPTION
…nstructor if the xaResourceRecoveryRegistry is not null