### PR TITLE
[WFTC-52] calling XATerminator when subordinate transaction is removed

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -67,6 +67,9 @@ public interface Log extends BasicLogger {
     @Message(value = "Unknown I/O error when listing xa resource recovery files in %s (File.list() returned null)")
     void listXAResourceRecoveryFilesNull(File dir);
 
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(value = "Error while removing imported transaction of xid %s from the underlying transaction manager")
+    void cannotRemoveImportedTransaction(Xid xid, @Cause XAException e);
 
     // Debug
 
@@ -111,6 +114,10 @@ public interface Log extends BasicLogger {
     @LogMessage(level = Logger.Level.TRACE)
     @Message(value = "Recovered in doubt xa resource (%s) from xa resource recovery registry %s")
     void xaResourceRecoveredFromRecoveryRegistry(URI uri, Path filePath);
+
+    @LogMessage(level = Logger.Level.TRACE)
+    @Message(value = "Unknown xid %s to be removed from the instances known to the wfly txn client")
+    void unknownXidToBeRemovedFromTheKnownTransactionInstances(Xid xid);
 
     // Regular messages
 

--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
@@ -226,7 +226,22 @@ public abstract class JBossLocalTransactionProvider implements LocalTransactionP
                         final ConcurrentMap<SimpleXid, Entry> known = JBossLocalTransactionProvider.this.known;
                         final Iterator<XidKey> iterator = timeoutSet.headSet(new XidKey(SimpleXid.EMPTY, timeTick)).iterator();
                         while (iterator.hasNext()) {
-                            known.remove(iterator.next().getId());
+                            SimpleXid xidToRemove = iterator.next().getId();
+                            Entry knownEntry = known.remove(xidToRemove);
+
+                            if (knownEntry == null) {
+                                Log.log.unknownXidToBeRemovedFromTheKnownTransactionInstances(xidToRemove);
+                            } else {
+                                final Transaction transaction = knownEntry.getTransaction();
+                                if (transaction instanceof ImportedTransaction) {
+                                    try {
+                                        ext.removeImportedTransaction(getXid(transaction));
+                                    } catch (XAException xae) {
+                                        Log.log.cannotRemoveImportedTransaction(xidToRemove, xae);
+                                    }
+                                }
+                            }
+
                             iterator.remove();
                         }
                     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFTC-52
https://developer.jboss.org/message/983112

when subordinate transaction is removed from the 'known' ones, we need to announce Narayana to clean its space too, otherwise there is memory leak happening

@dmlloyd  : I've tried to clean the code a bit while using your advises. Please, check this if it's based on your expectations. I tested it on the 1.1 branch with WFLY13 and from what I can say it works.
Btw. afterwards, will this be expected to be backported to 1.1 branch?