### PR TITLE
[WFTC-52] calling XATerminator when subordinate transaction is removed

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -58,12 +58,6 @@ public interface Log extends BasicLogger {
     @Message(value = "Subordinate XAResource at %s")
     String subordinateXaResource(URI location);
 
-    // Warn
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(value = "Error while removing imported transaction of xid %s from the underlying transaction manager")
-    void cannotRemoveImportedTransaction(Xid xid, @Cause XAException e);
-
     // Debug
 
     @LogMessage(level = Logger.Level.DEBUG)
@@ -367,4 +361,8 @@ public interface Log extends BasicLogger {
 
     @Message(id = 90, value = "Cannot assign location \"%s\" to transaction because it is already located at \"%s\"")
     IllegalStateException locationAlreadyInitialized(URI newLocation, URI oldLocation);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 99, value = "Error while removing imported transaction of xid %s from the underlying transaction manager")
+    void cannotRemoveImportedTransaction(Xid xid, @Cause XAException e);
 }

--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -58,6 +58,12 @@ public interface Log extends BasicLogger {
     @Message(value = "Subordinate XAResource at %s")
     String subordinateXaResource(URI location);
 
+    // Warn
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(value = "Error while removing imported transaction of xid %s from the underlying transaction manager")
+    void cannotRemoveImportedTransaction(Xid xid, @Cause XAException e);
+
     // Debug
 
     @LogMessage(level = Logger.Level.DEBUG)
@@ -81,6 +87,10 @@ public interface Log extends BasicLogger {
     @LogMessage(level = Logger.Level.TRACE)
     @Message(value = "Failure on running doRecover during initialization")
     void doRecoverFailureOnIntialization(@Cause Throwable e);
+
+    @LogMessage(level = Logger.Level.TRACE)
+    @Message(value = "Unknown xid %s to be removed from the instances known to the wfly txn client")
+    void unknownXidToBeRemovedFromTheKnownTransactionInstances(Xid xid);
 
     // Regular messages
 


### PR DESCRIPTION
when subordinate transaction is removed from the 'known' ones,
we need to announce Narayana to clean its space too, otherwise
there is memory leak happening

- [ ] awaiting ack