### PR TITLE
WFTC-55: Fix for warn log messages to be identified with id

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -61,16 +61,6 @@ public interface Log extends BasicLogger {
     @Message(value = "Subordinate XAResource at %s")
     String subordinateXaResource(URI location);
 
-    // Warn
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(value = "Unknown I/O error when listing xa resource recovery files in %s (File.list() returned null)")
-    void listXAResourceRecoveryFilesNull(File dir);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(value = "Error while removing imported transaction of xid %s from the underlying transaction manager")
-    void cannotRemoveImportedTransaction(Xid xid, @Cause XAException e);
-
     // Debug
 
     @LogMessage(level = Logger.Level.DEBUG)
@@ -415,4 +405,12 @@ public interface Log extends BasicLogger {
 
     @Message(id = 97, value = "Cannot enlist XA resource '%s' to transaction '%s' as timeout already elapsed")
     SystemException cannotEnlistToTimeOutTransaction(XAResource xaRes, Transaction transaction);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 98, value = "Unknown I/O error when listing xa resource recovery files in %s (File.list() returned null)")
+    void listXAResourceRecoveryFilesNull(File dir);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 99, value = "Error while removing imported transaction of xid %s from the underlying transaction manager")
+    void cannotRemoveImportedTransaction(Xid xid, @Cause XAException e);
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFTC-55

Fixing the WARN messages would be marked with id as by standard that all log messages of INFO and higher should generally have message IDs.

/cc @fl4via @dmlloyd @wolfc