### PR TITLE
[WFTC-54] forbid to enlist XAResource to a timeouted transaction

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
+++ b/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
@@ -18,8 +18,6 @@
 
 package org.wildfly.transaction.client;
 
-import static java.lang.Math.max;
-
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.InvalidTransactionException;
@@ -160,7 +158,8 @@ public final class LocalTransaction extends AbstractTransaction {
 
     public boolean enlistResource(final XAResource xaRes) throws RollbackException, IllegalStateException, SystemException {
         Assert.checkNotNullParam("xaRes", xaRes);
-        final int estimatedRemainingTime = max(1, getEstimatedRemainingTime());
+        final int estimatedRemainingTime = getEstimatedRemainingTime();
+        if(estimatedRemainingTime == 0) throw Log.log.cannotEnlistToTimeOutTransaction(xaRes, this);
         try {
             xaRes.setTransactionTimeout(estimatedRemainingTime);
         } catch (XAException e) {

--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -412,4 +412,7 @@ public interface Log extends BasicLogger {
 
     @Message(id = 96, value = "Unexpected exception on XA recovery")
     IllegalStateException unexpectedExceptionOnXAResourceRecovery(@Cause IOException e);
+
+    @Message(id = 97, value = "Cannot enlist XA resource '%s' to transaction '%s' as timeout already elapsed")
+    SystemException cannotEnlistToTimeOutTransaction(XAResource xaRes, Transaction transaction);
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFTC-54

if `XAResource` is to be enlisted to a transaction that already timeouted then rather throw an exception than continue with the enlistment (see https://issues.jboss.org/browse/WFTC-54?focusedCommentId=13677791#comment-13677791)

This changes the behaviour as the previously the enlistment was permitted and the timeout was changed to value `1` second despite the transaction already timed out.