### PR TITLE
when timeout is 0 then it's not valid value

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
+++ b/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
@@ -158,7 +158,8 @@ public final class LocalTransaction extends AbstractTransaction {
 
     public boolean enlistResource(final XAResource xaRes) throws RollbackException, IllegalStateException, SystemException {
         Assert.checkNotNullParam("xaRes", xaRes);
-        final int estimatedRemainingTime = getEstimatedRemainingTime();
+        int estimatedRemainingTime = getEstimatedRemainingTime();
+        if(getTransactionTimeout() == 0) estimatedRemainingTime = Integer.MAX_VALUE;
         if(estimatedRemainingTime == 0) throw Log.log.cannotEnlistToTimeOutTransaction(xaRes, this);
         try {
             xaRes.setTransactionTimeout(estimatedRemainingTime);


### PR DESCRIPTION
 which we consider to be provided by a faulty participant