### PR TITLE
[WFTC-56] At SubordinateXAResource.getRemainingTime(), divide elapsed…

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -228,6 +228,6 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
     int getRemainingTime() {
         long elapsed = max(0L, System.nanoTime() - startTime);
         final int capturedTimeout = this.capturedTimeout;
-        return capturedTimeout - (int) min(capturedTimeout, elapsed / 1_000_000L);
+        return capturedTimeout - (int) min(capturedTimeout, elapsed / 1_000_000_000L);
     }
 }


### PR DESCRIPTION
… by 1000000000 instead of 1000000 to obtain correct amount in seconds.

Jira: https://issues.jboss.org/browse/WFTC-56