### PR TITLE
[WTC-60] Fix conversion to seconds calculating the SubordinateXAResource transaction remaining timeout

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -228,6 +228,6 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
     int getRemainingTime() {
         long elapsed = max(0L, System.nanoTime() - startTime);
         final int capturedTimeout = this.capturedTimeout;
-        return capturedTimeout - (int) min(capturedTimeout, elapsed / 1_000_000L);
+        return capturedTimeout - (int) min(capturedTimeout, elapsed / 1_000_000_000L);
     }
 }


### PR DESCRIPTION
Fix the calculation of the remaining transaction timeout. The elapsed time is in nanoseconds but the capturedTimeout is in seconds, so we have to divide by 1_000_000_000L.

Jira issue: https://issues.jboss.org/browse/WFTC-60