### PR TITLE
[WTC-60] Fix conversion to seconds calculating the SubordinateXAResource transaction remaining timeout

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -228,6 +228,6 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
     int getRemainingTime() {
         long elapsed = max(0L, System.nanoTime() - startTime);
         final int capturedTimeout = this.capturedTimeout;
-        return capturedTimeout - (int) min(capturedTimeout, elapsed / 1_000_000L);
+        return capturedTimeout - (int) min(capturedTimeout, elapsed / 1_000_000_000L);
     }
 }


### PR DESCRIPTION
Backporting https://github.com/wildfly/wildfly-transaction-client/pull/71 to 1.1 branch

Jira issue: https://issues.jboss.org/browse/WFTC-60

It supersedes https://github.com/wildfly/wildfly-transaction-client/pull/68