### PR TITLE
[WFTC-61] the connection failures are intermittent and should be thrown as RMFAIL

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/provider/remoting/TransactionClientChannel.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/remoting/TransactionClientChannel.java
@@ -95,7 +95,7 @@ final class TransactionClientChannel implements RemotingOperations {
             final int peerIdentityId = peerIdentity.getId();
             if (peerIdentityId != 0) Protocol.writeParam(Protocol.P_SEC_CONTEXT, os, peerIdentityId, Protocol.UNSIGNED);
         } catch (IOException e) {
-            throw Log.log.failedToSendXA(e, XAException.XAER_RMERR);
+            throw Log.log.failedToSendXA(e, XAException.XAER_RMFAIL);
         }
         try (BlockingInvocation.Response response = invocation.getResponse()) {
             try (MessageInputStream is = response.getInputStream()) {
@@ -130,7 +130,7 @@ final class TransactionClientChannel implements RemotingOperations {
                     throw Log.log.unrecognizedParameter(XAException.XAER_RMFAIL, id);
                 }
             } catch (IOException e) {
-                throw Log.log.responseFailedXa(e, XAException.XAER_RMERR);
+                throw Log.log.responseFailedXa(e, XAException.XAER_RMFAIL);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -153,7 +153,7 @@ final class TransactionClientChannel implements RemotingOperations {
             final int peerIdentityId = peerIdentity.getId();
             if (peerIdentityId != 0) Protocol.writeParam(Protocol.P_SEC_CONTEXT, os, peerIdentityId, Protocol.UNSIGNED);
         } catch (IOException e) {
-            throw Log.log.failedToSendXA(e, XAException.XAER_RMERR);
+            throw Log.log.failedToSendXA(e, XAException.XAER_RMFAIL);
         }
         try (BlockingInvocation.Response response = invocation.getResponse()) {
             try (MessageInputStream is = response.getInputStream()) {
@@ -188,7 +188,7 @@ final class TransactionClientChannel implements RemotingOperations {
                     throw Log.log.unrecognizedParameter(XAException.XAER_RMFAIL, id);
                 }
             } catch (IOException e) {
-                throw Log.log.responseFailedXa(e, XAException.XAER_RMERR);
+                throw Log.log.responseFailedXa(e, XAException.XAER_RMFAIL);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -210,7 +210,7 @@ final class TransactionClientChannel implements RemotingOperations {
             final int peerIdentityId = peerIdentity.getId();
             if (peerIdentityId != 0) Protocol.writeParam(Protocol.P_SEC_CONTEXT, os, peerIdentityId, Protocol.UNSIGNED);
         } catch (IOException e) {
-            throw Log.log.failedToSendXA(e, XAException.XAER_RMERR);
+            throw Log.log.failedToSendXA(e, XAException.XAER_RMFAIL);
         }
         try (BlockingInvocation.Response response = invocation.getResponse()) {
             try (MessageInputStream is = response.getInputStream()) {
@@ -245,7 +245,7 @@ final class TransactionClientChannel implements RemotingOperations {
                     throw Log.log.unrecognizedParameter(XAException.XAER_RMFAIL, id);
                 }
             } catch (IOException e) {
-                throw Log.log.responseFailedXa(e, XAException.XAER_RMERR);
+                throw Log.log.responseFailedXa(e, XAException.XAER_RMFAIL);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -268,7 +268,7 @@ final class TransactionClientChannel implements RemotingOperations {
             final int peerIdentityId = peerIdentity.getId();
             if (peerIdentityId != 0) Protocol.writeParam(Protocol.P_SEC_CONTEXT, os, peerIdentityId, Protocol.UNSIGNED);
         } catch (IOException e) {
-            throw Log.log.failedToSendXA(e, XAException.XAER_RMERR);
+            throw Log.log.failedToSendXA(e, XAException.XAER_RMFAIL);
         }
         try (BlockingInvocation.Response response = invocation.getResponse()) {
             try (MessageInputStream is = response.getInputStream()) {
@@ -305,7 +305,7 @@ final class TransactionClientChannel implements RemotingOperations {
                     throw Log.log.unrecognizedParameter(XAException.XAER_RMFAIL, id);
                 }
             } catch (IOException e) {
-                throw Log.log.responseFailedXa(e, XAException.XAER_RMERR);
+                throw Log.log.responseFailedXa(e, XAException.XAER_RMFAIL);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -328,7 +328,7 @@ final class TransactionClientChannel implements RemotingOperations {
             final int peerIdentityId = peerIdentity.getId();
             if (peerIdentityId != 0) Protocol.writeParam(Protocol.P_SEC_CONTEXT, os, peerIdentityId, Protocol.UNSIGNED);
         } catch (IOException e) {
-            throw Log.log.failedToSendXA(e, XAException.XAER_RMERR);
+            throw Log.log.failedToSendXA(e, XAException.XAER_RMFAIL);
         }
         try (BlockingInvocation.Response response = invocation.getResponse()) {
             try (MessageInputStream is = response.getInputStream()) {
@@ -363,7 +363,7 @@ final class TransactionClientChannel implements RemotingOperations {
                     throw Log.log.unrecognizedParameter(XAException.XAER_RMFAIL, id);
                 }
             } catch (IOException e) {
-                throw Log.log.responseFailedXa(e, XAException.XAER_RMERR);
+                throw Log.log.responseFailedXa(e, XAException.XAER_RMFAIL);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -386,7 +386,7 @@ final class TransactionClientChannel implements RemotingOperations {
             if (peerIdentityId != 0) Protocol.writeParam(Protocol.P_SEC_CONTEXT, os, peerIdentityId, Protocol.UNSIGNED);
             if (onePhase) Protocol.writeParam(Protocol.P_ONE_PHASE, os);
         } catch (IOException e) {
-            throw Log.log.failedToSendXA(e, XAException.XAER_RMERR);
+            throw Log.log.failedToSendXA(e, XAException.XAER_RMFAIL);
         }
         try (BlockingInvocation.Response response = invocation.getResponse()) {
             try (MessageInputStream is = response.getInputStream()) {
@@ -447,7 +447,7 @@ final class TransactionClientChannel implements RemotingOperations {
             if (peerIdentityId != 0) Protocol.writeParam(Protocol.P_SEC_CONTEXT, os, peerIdentityId, Protocol.UNSIGNED);
             Protocol.writeParam(Protocol.P_PARENT_NAME, os, parentName);
         } catch (IOException e) {
-            throw Log.log.failedToSendXA(e, XAException.XAER_RMERR);
+            throw Log.log.failedToSendXA(e, XAException.XAER_RMFAIL);
         }
         final ArrayList<Xid> recoveryList = new ArrayList<>();
         try (BlockingInvocation.Response response = invocation.getResponse()) {
@@ -495,7 +495,7 @@ final class TransactionClientChannel implements RemotingOperations {
             Thread.currentThread().interrupt();
             throw Log.log.interruptedXA(XAException.XAER_RMERR);
         } catch (IOException e) {
-            throw Log.log.responseFailedXa(e, XAException.XAER_RMERR);
+            throw Log.log.responseFailedXa(e, XAException.XAER_RMFAIL);
         }
     }
 


### PR DESCRIPTION
...and should be announced as such to transaction manager

https://issues.jboss.org/browse/WFTC-61
https://issues.jboss.org/browse/WFLY-11937

@fl4via @tadamski this fix changes the error codes from `XAER_RMERR` to `XAER_RMFAIL` when `IOException` is received from the remote call. The failed remote call means that the action could be repeated to find out the outcome of the transaction. The `RMERR` defines an un-recoverable error and in such case the transaction is moved to heuristic and operator needs to do manual change.

I did the change not only for the `BlockingInvocation.Response response = invocation.getResponse()` but for the code at `// write rollback-only request`. I think it's correct to be changed there as well but if you can @fl4via take a look to confirm I would be grateful.