### PR TITLE
[WFTC-62] At FileSystemXAResourceRegistry.XAResourceRegistryFile.load…

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/FileSystemXAResourceRegistry.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/FileSystemXAResourceRegistry.java
@@ -312,6 +312,7 @@ final class FileSystemXAResourceRegistry {
                     throw Log.log.readURIFromXAResourceRecoveryFileFailed(uriString, filePath, e);
                 }
                 final XAResource xaresource = reloadInDoubtResource(uri, nodeName);
+                resources.add(xaresource);
                 inDoubtResources.add(xaresource);
                 Log.log.xaResourceRecoveredFromRecoveryRegistry(uri, filePath);
             }


### PR DESCRIPTION
…InDoubtResources, add the loaded resource to resources list, so we can keep track when the list is cleared and the log file is ready for deletion in the file system

Jira: https://issues.jboss.org/browse/WFTC-62