### PR TITLE
[WFTC-64] At SubordinateXAResource.recover, check if there are no rec…

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -198,7 +198,10 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
     }
 
     public Xid[] recover(final int flag, final String parentName) throws XAException {
-        return getProvider().getPeerHandleForXa(location, null, null).recover(flag, parentName);
+        Xid[] recoveredXids = getProvider().getPeerHandleForXa(location, null, null).recover(flag, parentName);
+        if (recoveredXids.length == 0 && resourceRegistry != null)
+            resourceRegistry.removeResource(this);
+        return recoveredXids;
     }
 
     public boolean isSameRM(final XAResource xaRes) throws XAException {


### PR DESCRIPTION
…overed Xids. This means that there's nothing to recover and that the resource must be removed from the file system.

Jira: https://issues.jboss.org/browse/WFTC-64