### PR TITLE
[WFTC-65] (master) no NPE on non-existing provider on resource enlistment

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -190,7 +190,11 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
     }
 
     private RemoteTransactionProvider getProvider() {
-        return RemoteTransactionContext.getInstancePrivate().getProvider(location);
+        RemoteTransactionProvider provider = RemoteTransactionContext.getInstancePrivate().getProvider(location);
+        if (provider == null) {
+            throw Log.log.noProviderForUri(location);
+        }
+        return provider;
     }
 
     public Xid[] recover(final int flag) throws XAException {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFTC-65

When provider for enlistment of XAResource is not available for particular 'uri' NPE should not be thrown.