### PR TITLE
WFTC-68 Memory leak in wildfly transaction client

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/FileSystemXAResourceRegistry.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/FileSystemXAResourceRegistry.java
@@ -241,13 +241,13 @@ final class FileSystemXAResourceRegistry {
          * fully prepared. In this case, any lines in the registry can correspond to in doubt outflowed
          * resources. The goal is to reload those resources so they can be recovered.
          *
-         * @param inDoubtFilePath the file path of the in doubt registry
-         * @throws IOException if there is an I/O error when realoding the registry file
+         * @param inDoubtFileName the file name of the in doubt registry
+         * @throws IOException if there is an I/O error when reloading the registry file
          */
-        private XAResourceRegistryFile(String inDoubtFilePath, LocalTransactionProvider provider) throws IOException {
-            this.filePath = xaRecoveryPath.resolve(inDoubtFilePath);
+        private XAResourceRegistryFile(String inDoubtFileName, LocalTransactionProvider provider) throws IOException {
+            this.filePath = xaRecoveryPath.resolve(inDoubtFileName);
             this.fileChannel = null; // no need to open file channel here
-            openFilePaths.add(inDoubtFilePath);
+            openFilePaths.add(inDoubtFileName);
             loadInDoubtResources(provider.getNodeName());
             Log.log.xaResourceRecoveryRegistryReloaded(filePath);
         }

--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/FileSystemXAResourceRegistry.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/FileSystemXAResourceRegistry.java
@@ -17,19 +17,6 @@
  */
 package org.wildfly.transaction.client.provider.jboss;
 
-import static java.security.AccessController.doPrivileged;
-
-import org.wildfly.common.annotation.NotNull;
-import org.wildfly.transaction.client.LocalTransaction;
-import org.wildfly.transaction.client.SimpleXid;
-import org.wildfly.transaction.client.XAResourceRegistry;
-import org.wildfly.transaction.client._private.Log;
-import org.wildfly.transaction.client.spi.LocalTransactionProvider;
-
-import javax.transaction.SystemException;
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-import javax.transaction.xa.Xid;
 import java.io.File;
 import java.io.FilePermission;
 import java.io.IOException;
@@ -42,13 +29,25 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.transaction.SystemException;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.wildfly.common.annotation.NotNull;
+import org.wildfly.transaction.client.LocalTransaction;
+import org.wildfly.transaction.client.SimpleXid;
+import org.wildfly.transaction.client.XAResourceRegistry;
+import org.wildfly.transaction.client._private.Log;
+import org.wildfly.transaction.client.spi.LocalTransactionProvider;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * A registry persisted in a series of log files, containing all outflowed resources info for unfinished transactions.
@@ -286,7 +285,7 @@ final class FileSystemXAResourceRegistry {
                             fileChannel.close();
                         }
                         Files.delete(filePath);
-                        openFilePaths.remove(filePath.toString());
+                        openFilePaths.remove(filePath.getFileName().toString());
                     } catch (IOException e) {
                         throw Log.log.deleteXAResourceRecoveryFileFailed(XAException.XAER_RMERR, filePath, resource, e);
                     }


### PR DESCRIPTION
Use the file name of the path instead of the full path as the key to remove entry from openFilePaths.