### PR TITLE
[WFTC-70](master)  removing XA file record only on recover start scan

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -201,7 +201,7 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
 
     public Xid[] recover(final int flag, final String parentName) throws XAException {
         Xid[] recoveredXids = getProvider().getPeerHandleForXa(location, null, null).recover(flag, parentName);
-        if (recoveredXids.length == 0 && resourceRegistry != null)
+        if ((flag & XAResource.TMSTARTRSCAN) == XAResource.TMSTARTRSCAN && recoveredXids.length == 0 && resourceRegistry != null)
             resourceRegistry.removeResource(this);
         return recoveredXids;
     }

--- a/src/main/java/org/wildfly/transaction/client/provider/remoting/TransactionClientChannel.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/remoting/TransactionClientChannel.java
@@ -434,7 +434,7 @@ final class TransactionClientChannel implements RemotingOperations {
 
     @NotNull
     public Xid[] recover(final int flag, final String parentName, final ConnectionPeerIdentity peerIdentity) throws XAException {
-        if (flag != XAResource.TMSTARTRSCAN) {
+        if ((flag & XAResource.TMSTARTRSCAN) != XAResource.TMSTARTRSCAN) {
             return SimpleXid.NO_XIDS;
         }
         final InvocationTracker invocationTracker = getInvocationTracker();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFTC-70

1.1 branch PR: https://github.com/wildfly/wildfly-transaction-client/pull/89

This is a regression from fix WFTC-64 where file descriptor is removed
just when no xids are returned. But the XAResource.recover
can be called with different flags and for particular flags
(e.g. `TMENDRSCAN`) no xids are expected to be returned.

The file descriptor can be deleted only when real remote call
is processed which is when `TMSTARTRSCAN` is passed as the flag.