### PR TITLE
[WFTC-75] unfinished XA commit records needs to be recorded for recovery

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -166,7 +166,7 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
         try {
             if (commitToEnlistment()) lookup(xid).commit(onePhase);
         } catch (XAException | RuntimeException exception) {
-            if (onePhase && resourceRegistry != null)
+            if (resourceRegistry != null)
                 resourceRegistry.resourceInDoubt(this);
             throw exception;
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFTC-75
https://issues.jboss.org/browse/JBEAP-17347

@fl4via would you be so kind and review this PR if it's right? What happens is that for failure on XA commit processing the registry does not return the XA resource during recovery. That makes the recovery not deleting the WFTC registry file.

When this will be approved I will create a PR for 1.1 branch. I would need this being fixed for CD18 (aka. JBEAP-17347)

/cc @chengfang 