### PR TITLE
[WFTC-82] XAResourceRegistry is clean only for XAResource.recover TMSTARTSCAN

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
+++ b/src/main/java/org/wildfly/transaction/client/SubordinateXAResource.java
@@ -211,7 +211,7 @@ final class SubordinateXAResource implements XAResource, XARecoverable, Serializ
 
     public Xid[] recover(final int flag, final String parentName) throws XAException {
         Xid[] recoveredXids = getRemoteTransactionPeer().recover(flag, parentName);
-        if ((flag & (XAResource.TMSTARTRSCAN | XAResource.TMENDRSCAN)) > 0 && recoveredXids.length == 0 && resourceRegistry != null)
+        if ((flag & XAResource.TMSTARTRSCAN) == XAResource.TMSTARTRSCAN && recoveredXids.length == 0 && resourceRegistry != null)
             resourceRegistry.removeResource(this);
         return recoveredXids;
     }


### PR DESCRIPTION
…and not for TMENDRSCAN as well

https://issues.redhat.com/browse/WFTC-82