### PR TITLE
[WFTC-85] adding xaregistry register to be used for serialized xa resources

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/XAOutflowedResources.java
+++ b/src/main/java/org/wildfly/transaction/client/XAOutflowedResources.java
@@ -56,9 +56,6 @@ final class XAOutflowedResources {
             }
             final XAResourceRegistry resourceRegistry = transaction.getProvider().getXAResourceRegistry(transaction);
             xaResource = new SubordinateXAResource(location, parentName, resourceRegistry);
-            if (resourceRegistry != null) {
-                resourceRegistry.addResource(xaResource, location);
-            }
             if (! transaction.enlistResource(xaResource)) {
                 throw Log.log.couldNotEnlist();
             }

--- a/src/main/java/org/wildfly/transaction/client/XAResourceRegistry.java
+++ b/src/main/java/org/wildfly/transaction/client/XAResourceRegistry.java
@@ -21,6 +21,7 @@ package org.wildfly.transaction.client;
 import javax.transaction.SystemException;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
 import java.net.URI;
 
 import static org.wildfly.transaction.client.OutflowHandleManager.FL_COMMITTED;
@@ -42,7 +43,7 @@ public abstract class XAResourceRegistry {
      * @param uri the resource URI location
      * @throws SystemException if there is a problem recording this resource
      */
-    protected abstract void addResource(XAResource resource, URI uri) throws SystemException;
+    protected abstract void addResource(XAResource resource, Xid xid, URI uri) throws SystemException;
 
     /**
      * Removes a XA resource from this registry.
@@ -69,7 +70,7 @@ public abstract class XAResourceRegistry {
      * @param nodeName the node name of the resource
      * @return         a newly-created resource representing a previously lost XA resource that is in doubt
      */
-    protected XAResource reloadInDoubtResource(URI uri, String nodeName) {
-        return new SubordinateXAResource(uri, nodeName, FL_COMMITTED | FL_CONFIRMED, this);
+    protected XAResource reloadInDoubtResource(URI uri, String nodeName, Xid xid) {
+        return new SubordinateXAResource(uri, nodeName, xid, FL_COMMITTED | FL_CONFIRMED, this);
     }
 }

--- a/src/main/java/org/wildfly/transaction/client/XAResourceRegistryProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/XAResourceRegistryProvider.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.transaction.client;
+
+import javax.transaction.xa.XAResource;
+
+/**
+ * <p>
+ * Interface which provides ability to list in-doubt {@link XAResource}s at the time.
+ * These XAResources are taken cross all instances of the {@link XAResourceRegistry}.
+ * </p>
+ * <p>
+ * The provider is used to compare currently existing XAResource registry records
+ * to running commit commands if the XAResource (or rather {@link SubordinateXAResource} is not connected to
+ * an existing registry instance.
+ * </p>
+ */
+public interface XAResourceRegistryProvider {
+
+    /**
+     * <p>
+     * List all in-doubt XAResources over all instances of the {@link XAResourceRegistry} known to provider.
+     * </p>
+     * <p>
+     * Let's say we have a provider which is based on the file system. Then there are several files where each file
+     * represents one {@link XAResourceRegistry} record. This method returns all data from all the records.
+     * </p>
+     *
+     * @return list of in-doubt {@link XAResource}s previously saved via handling of {@link XAResourceRegistry}.
+     */
+    XAResource[] getInDoubtXAResources();
+}

--- a/src/main/java/org/wildfly/transaction/client/XAResourceRegistryProviderHolder.java
+++ b/src/main/java/org/wildfly/transaction/client/XAResourceRegistryProviderHolder.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.transaction.client;
+
+/**
+ * A single point to take a currently configured provider that is capable to list all the in-doubt
+ * {@link javax.transaction.xa.XAResource}s from the all records maintained as {@link XAResourceRegistry} instances.
+ */
+public final class XAResourceRegistryProviderHolder {
+    private static XAResourceRegistryProvider INSTANCE;
+
+    /**
+     * Returning instance of the currently configured {@link XAResourceRegistryProvider}.
+     *
+     * @return xaresource registry provider instance which was {@link #register(XAResourceRegistryProvider)}ed
+     *         beforehand manually in the code
+     */
+    public static XAResourceRegistryProvider getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Registering the {@link XAResourceRegistryProvider}. This give a way how
+     * to approach the in-doubt {@link javax.transaction.xa.XAResource}s when the {@link SubordinateXAResource}
+     * is not linked with the {@link XAResourceRegistry}.
+     *
+     * @param xaResourceRegistryProvider
+     */
+    public static void register(XAResourceRegistryProvider xaResourceRegistryProvider) {
+        INSTANCE = xaResourceRegistryProvider;
+    }
+}

--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -61,6 +61,9 @@ public interface Log extends BasicLogger {
     @Message(value = "Subordinate XAResource at %s")
     String subordinateXaResource(URI location);
 
+    @Message(value = "Failed to add XAResource %s with Xid %s pointing to location %s to XAResourceRegistry")
+    String failedToAddXAResourceToRegistry(XAResource xaResource, Xid xid, URI location);
+
     // Debug
 
     @LogMessage(level = Logger.Level.DEBUG)
@@ -414,4 +417,11 @@ public interface Log extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 99, value = "Error while removing imported transaction of xid %s from the underlying transaction manager")
     void cannotRemoveImportedTransaction(Xid xid, @Cause XAException e);
+
+    @Message(id = 100, value = "String '%s' has a wrong format to be decoded to SimpleXid. Expected the hexadecimal " +
+        "format separated by '%s' to exactly three parts.")
+    IllegalStateException failToConvertHexadecimalFormatToSimpleXid(String stringToConvert, String separator);
+
+    @Message(id = 101, value = "Failed to read Xid '%s' from xa resource recovery file %s")
+    IOException readXidFromXAResourceRecoveryFileFailed(String xidString, Path filePath, @Cause Exception e);
 }

--- a/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/provider/jboss/JBossLocalTransactionProvider.java
@@ -60,6 +60,7 @@ import org.wildfly.transaction.client.LocalTransaction;
 import org.wildfly.transaction.client.SimpleXid;
 import org.wildfly.transaction.client.XAImporter;
 import org.wildfly.transaction.client.XAResourceRegistry;
+import org.wildfly.transaction.client.XAResourceRegistryProviderHolder;
 import org.wildfly.transaction.client._private.Log;
 import org.wildfly.transaction.client.spi.LocalTransactionProvider;
 import org.wildfly.transaction.client.spi.SubordinateTransactionControl;
@@ -95,6 +96,7 @@ public abstract class JBossLocalTransactionProvider implements LocalTransactionP
             Log.log.doRecoverFailureOnIntialization(e);
         }
         this.fileSystemXAResourceRegistry = new FileSystemXAResourceRegistry(this, xaRecoveryDirRelativeToPath);
+        XAResourceRegistryProviderHolder.register(fileSystemXAResourceRegistry::getInDoubtXAResources);
         registry.addXAResourceRecovery(fileSystemXAResourceRegistry::getInDoubtXAResources);
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFTC-85

Finding the cross reference between the registry and the xid of the resource being committed.

I have got an integration test which will be part of WFLY testsuite (https://issues.redhat.com/browse/WFLY-13578)

/CC @fl4via @tadamski 