### PR TITLE
[WFTC-86] finished transaction should be removed from memory mapping

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
+++ b/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
@@ -62,6 +62,9 @@ public final class LocalTransaction extends AbstractTransaction {
             if (outflowedResources == null || outflowedResources.getEnlistedSubordinates() == 0) {
                 // we can drop the mapping, since we are both a master and have no enlisted subordinates
                 owner.getProvider().dropLocal(transaction);
+            } else {
+                // the memory mapping of transaction with subordinate enlistment may need to be adjusted
+                owner.getProvider().dropRemote(transaction);
             }
         }
     }
@@ -81,6 +84,9 @@ public final class LocalTransaction extends AbstractTransaction {
             if (outflowedResources == null || outflowedResources.getEnlistedSubordinates() == 0) {
                 // we can drop the mapping, since we are both a master and have no enlisted subordinates
                 owner.getProvider().dropLocal(transaction);
+            } else {
+                // the memory mapping of transaction with subordinate enlistment may need to be adjusted
+                owner.getProvider().dropRemote(transaction);
             }
         }
     }
@@ -96,6 +102,9 @@ public final class LocalTransaction extends AbstractTransaction {
             if (outflowedResources == null || outflowedResources.getEnlistedSubordinates() == 0) {
                 // we can drop the mapping, since we are both a master and have no enlisted subordinates
                 owner.getProvider().dropLocal(transaction);
+            } else {
+                // the memory mapping of transaction with subordinate enlistment may need to be adjusted
+                owner.getProvider().dropRemote(transaction);
             }
         }
     }
@@ -112,6 +121,9 @@ public final class LocalTransaction extends AbstractTransaction {
             if (outflowedResources == null || outflowedResources.getEnlistedSubordinates() == 0) {
                 // we can drop the mapping, since we are both a master and have no enlisted subordinates
                 owner.getProvider().dropLocal(transaction);
+            } else {
+                // the memory mapping of transaction with subordinate enlistment may need to be adjusted
+                owner.getProvider().dropRemote(transaction);
             }
         }
     }

--- a/src/main/java/org/wildfly/transaction/client/spi/LocalTransactionProvider.java
+++ b/src/main/java/org/wildfly/transaction/client/spi/LocalTransactionProvider.java
@@ -175,6 +175,18 @@ public interface LocalTransactionProvider extends TransactionProvider {
     void dropLocal(@NotNull Transaction transaction);
 
     /**
+     * The transaction is expected to work with outflowed resources - it contains a remote subordinate enlistment.
+     * We can't use the {@link #dropLocal(Transaction)} directly as the the transaction may reapear
+     * on this node during recovery.
+     *
+     * But this method gives a chance to the provider to reassign the removal timeout or some other work
+     * that needs to be done in case the in-flight transaction finished.
+     *
+     * @param transaction the transaction with ouflowed resources to announce of being finished (not {@code null})
+     */
+    void dropRemote(@NotNull Transaction transaction);
+
+    /**
      * Get the configured timeout of the given transaction (not the remaining time).
      *
      * @param transaction the transaction (not {@code null})
@@ -350,6 +362,10 @@ public interface LocalTransactionProvider extends TransactionProvider {
         }
 
         public void dropLocal(@NotNull final Transaction transaction) {
+            // no operation
+        }
+
+        public void dropRemote(@NotNull final Transaction transaction) {
             // no operation
         }
 


### PR DESCRIPTION
The transaction with remote enlistment should be held in memory only for time of `staleTransactionTimeout` after it is being completed.

https://issues.redhat.com/browse/WFTC-86