### PR TITLE
WFTC-93 RemotingRemoteTransactionPeer#getPeerIdentityXA should handle CancellationException.

### DIFF
--- a/javaee/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/javaee/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -217,7 +217,7 @@ public interface Log extends BasicLogger {
     IllegalStateException multipleProvidersRegistered(Endpoint e);
 
     @Message(id = 34, value = "Failed to acquire a connection for this operation")
-    XAException failedToAcquireConnectionXA(@Cause IOException e, @Field int errorCode);
+    XAException failedToAcquireConnectionXA(@Cause Throwable e, @Field int errorCode);
 
     @Message(id = 35, value = "Invalid handle type requested; expected a subtype of Transaction (non-inclusive), got %s")
     IllegalArgumentException invalidHandleTypeRequested(Class<?> type);

--- a/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
+++ b/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.net.ssl.SSLContext;
 import javax.transaction.SystemException;
@@ -93,7 +93,7 @@ class RemotingRemoteTransactionPeer implements RemoteTransactionPeer {
     ConnectionPeerIdentity getPeerIdentityXA() throws XAException {
         try {
             return getPeerIdentity();
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | CancellationException e) {
             throw Log.log.failedToAcquireConnectionXA(e, XAException.XAER_RMFAIL);
         }
     }

--- a/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
+++ b/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
@@ -87,17 +87,13 @@ class RemotingRemoteTransactionPeer implements RemoteTransactionPeer {
         } else {
             finalAuthenticationConfiguration = authenticationConfiguration;
         }
-        try {
-            return endpoint.getConnectedIdentity(location, finalSslContext, finalAuthenticationConfiguration).get();
-        } catch (CancellationException e) {
-            throw new IOException(e);
-        }
+        return endpoint.getConnectedIdentity(location, finalSslContext, finalAuthenticationConfiguration).get();
     }
 
     ConnectionPeerIdentity getPeerIdentityXA() throws XAException {
         try {
             return getPeerIdentity();
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             throw Log.log.failedToAcquireConnectionXA(e, XAException.XAER_RMFAIL);
         }
     }

--- a/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
+++ b/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CancellationException;
 
 import javax.net.ssl.SSLContext;
 import javax.transaction.SystemException;

--- a/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
+++ b/javaee/src/main/java/org/wildfly/transaction/client/provider/remoting/RemotingRemoteTransactionPeer.java
@@ -86,7 +86,11 @@ class RemotingRemoteTransactionPeer implements RemoteTransactionPeer {
         } else {
             finalAuthenticationConfiguration = authenticationConfiguration;
         }
-        return endpoint.getConnectedIdentity(location, finalSslContext, finalAuthenticationConfiguration).get();
+        try {
+            return endpoint.getConnectedIdentity(location, finalSslContext, finalAuthenticationConfiguration).get();
+        } catch (CancellationException e) {
+            throw new IOException(e);
+        }
     }
 
     ConnectionPeerIdentity getPeerIdentityXA() throws XAException {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFTC-93

When CancellationException is thrown, throw XaException.XAER_RMFAIL.
Based on Javadoc for [org.jboss.xnio.IoFuture.get()](https://docs.jboss.org/xnio/1.1/api/org/jboss/xnio/IoFuture.html#get()) method,
it can throw:

- IOException - if the operation failed 
- InterruptedException - if the operation is interrupted 
- CancellationException - if the operation was cancelled

Current code is only able to handle IOException, when "CancellationException" is thrown, this will result on such exception to be thrown back to the Transaction Manager, which is not valid. Only XaException with appropriate error code can be thrown.
