### PR TITLE
WFTC-118 Upgrade xnio to 3.8.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <version.org.jboss.narayana>5.5.30.Final</version.org.jboss.narayana>
         <version.org.jboss.remoting>5.0.23.Final</version.org.jboss.remoting>
         <version.org.jboss.spec.javax.transaction>1.0.1.Final</version.org.jboss.spec.javax.transaction>
-        <version.org.jboss.xnio>3.5.1.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.8.Final</version.org.jboss.xnio>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>
         <version.org.wildfly.common>1.2.0.Final</version.org.wildfly.common>
         <version.org.wildfly.elytron>1.1.0.Final</version.org.wildfly.elytron>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFTC-118

this is to port https://github.com/wildfly/wildfly-transaction-client/pull/137 from master branch to 2.x branch.