### PR TITLE
[WFTC-138] Add access checking API to TxnNamingContextFactory

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/naming/txn/TxnNamingContext.java
+++ b/src/main/java/org/wildfly/transaction/client/naming/txn/TxnNamingContext.java
@@ -52,13 +52,19 @@ class TxnNamingContext extends AbstractContext {
     private final ProviderEnvironment providerEnvironment;
     private final RemoteUserTransaction remoteUserTransaction;
 
-    TxnNamingContext(final NamingProvider namingProvider, final ProviderEnvironment providerEnvironment) {
+    private final TxnNamingContextFactory.AccessChecker accessChecker;
+
+    TxnNamingContext(final NamingProvider namingProvider, final ProviderEnvironment providerEnvironment, final TxnNamingContextFactory.AccessChecker accessChecker) {
         this.namingProvider = namingProvider;
         this.providerEnvironment = providerEnvironment;
+        this.accessChecker = accessChecker;
         remoteUserTransaction = getRemoteUserTransaction();
     }
 
     protected Object lookupNative(final Name name) throws NamingException {
+        if (accessChecker != null) {
+            accessChecker.checkAccessAllowed();
+        }
         final String str = name.get(0);
         switch (str) {
             case USER_TRANSACTION: {

--- a/src/main/java/org/wildfly/transaction/client/naming/txn/TxnNamingContextFactory.java
+++ b/src/main/java/org/wildfly/transaction/client/naming/txn/TxnNamingContextFactory.java
@@ -34,11 +34,23 @@ import org.wildfly.naming.client.util.FastHashtable;
  */
 @MetaInfServices
 public final class TxnNamingContextFactory implements NamingContextFactory {
+
+
+    private static AccessChecker accessChecker = null;
+
     public boolean supportsUriScheme(final NamingProvider namingProvider, final String nameScheme) {
         return nameScheme != null && nameScheme.equals("txn");
     }
 
     public Context createRootContext(final NamingProvider namingProvider, final String nameScheme, final FastHashtable<String, Object> env, final ProviderEnvironment providerEnvironment) throws NamingException {
-        return new TxnNamingContext(namingProvider, providerEnvironment);
+        return new TxnNamingContext(namingProvider, providerEnvironment, accessChecker);
+    }
+
+    public static void setAccessChecker(final AccessChecker accessChecker) {
+        TxnNamingContextFactory.accessChecker = accessChecker;
+    }
+
+    public interface AccessChecker {
+        void checkAccessAllowed() throws NamingException;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFTC-138

I need this API to proceed with access checking from txn namespace from within WildFly. @chengfang please review.