### PR TITLE
[WFTC-141] Wildfly-transaction-client doesn't log that the transaction timeout wasn't set, when the driver returns false

### DIFF
--- a/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
+++ b/src/main/java/org/wildfly/transaction/client/LocalTransaction.java
@@ -173,7 +173,9 @@ public final class LocalTransaction extends AbstractTransaction {
         final int estimatedRemainingTime = getEstimatedRemainingTime();
         if(estimatedRemainingTime == 0) throw Log.log.cannotEnlistToTimeOutTransaction(xaRes, this);
         try {
-            xaRes.setTransactionTimeout(estimatedRemainingTime);
+            if (!xaRes.setTransactionTimeout(estimatedRemainingTime)) {
+                Log.log.setTimeoutUnsuccessful(estimatedRemainingTime);
+            }
         } catch (XAException e) {
             throw Log.log.setTimeoutFailed(estimatedRemainingTime, e);
         }

--- a/src/main/java/org/wildfly/transaction/client/_private/Log.java
+++ b/src/main/java/org/wildfly/transaction/client/_private/Log.java
@@ -423,4 +423,8 @@ public interface Log extends BasicLogger {
 
     @Message(id = 101, value = "Failed to read Xid '%s' from xa resource recovery file %s")
     IOException readXidFromXAResourceRecoveryFileFailed(String xidString, Path filePath, @Cause Exception e);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 102, value = "Failed to set transaction timeout of %d")
+    void setTimeoutUnsuccessful(int timeout);
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFTC-141