### PR TITLE
Use jdk 25 + for CI

### DIFF
--- a/.github/workflows/ci-manual.yml
+++ b/.github/workflows/ci-manual.yml
@@ -30,11 +30,10 @@ on:
       jdk-version:
         description: 'JDK Version'
         required: false
-        default: '11'
+        default: '25'
         type: choice
         options:
-          - 11
-          - 17
+          - 25
 
 jobs:
   build-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         jdk-distribution: [temurin]
-        jdk-version: [17, 21, 25]
+        jdk-version: [25]
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.jdk-distribution }} ${{ matrix.jdk-version }}

--- a/.github/workflows/ejb-client.yml
+++ b/.github/workflows/ejb-client.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         jdk-distribution: [temurin]
-        jdk-version: [17]
+        jdk-version: [25]
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.jdk-distribution }} ${{ matrix.jdk-version }}

--- a/.github/workflows/wildfly.yml
+++ b/.github/workflows/wildfly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         jdk-distribution: [temurin]
-        jdk-version: [17]
+        jdk-version: [25]
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.jdk-distribution }} ${{ matrix.jdk-version }}


### PR DESCRIPTION
As discussed with Tomek, since the bump update of jboss-parent to version 52 jdks 11 and 17 fail. So I am opening this PR to use jdk 25 in CI so that tests can pass again.
Please feel free to reject it if the jdks 11 and 17 are still  needed